### PR TITLE
Fix the gameinfo for h++ users (no more error overlays)

### DIFF
--- a/GameInfo.txt
+++ b/GameInfo.txt
@@ -49,6 +49,7 @@
 			gamebin				|gameinfo_path|bin
 
 			// Last, mount in shared HL2 loose files
+                        game                            |all_source_engine_paths|hammer
 			game				|all_source_engine_paths|hl2
 			platform			|all_source_engine_paths|platform
 		}


### PR DESCRIPTION
Adds a new line in the last section to mount editor entities